### PR TITLE
refactor(core, adapters/onebotv11): 重构命令执行返回类型，优化驱动程序

### DIFF
--- a/core/protocol.py
+++ b/core/protocol.py
@@ -149,6 +149,7 @@ class ActionRequest(MessageBase):
     type: str  # 动作类型 (send_message, delete_message, kick_member, etc.)
     target: Union[UserInfo, GroupInfo]  # 目标对象
     data: dict  # 动作数据
+    group: Optional[GroupInfo] = None  # 群组信息
     delay: Optional[float] = None  # 延迟执行时间（秒）
 
 @dataclass

--- a/core/register.py
+++ b/core/register.py
@@ -87,7 +87,7 @@ class Register:
             return result
         raise ValueError(f"Function {function_name} not found, probably you forget register it")
 
-    async def execute_command(self, event: CommandEvent) -> Union[MessageRequest, ActionRequest, MessageEvent, NoticeEvent, CommandEvent, None]:
+    async def execute_command(self, event: CommandEvent) -> Union[MessageBase, None]:
         """执行命令"""
         logger.debug(f"Executing command {event.command} from {event.user.user_id} in {event.group.group_id if event.group else None} with args {event.args}")
         
@@ -121,7 +121,7 @@ class Register:
         
         try:
             result = await handler(event)
-            if isinstance(result, (MessageRequest, ActionRequest, MessageEvent, NoticeEvent, CommandEvent)):
+            if isinstance(result, MessageBase):
                 return result
             else:
                 return MessageRequest(


### PR DESCRIPTION
## What' new
- 在 ActionRequest 类中添加 group 字段，用于提供群组信息
- 将 Register 类中的 execute_command 方法返回类型简化
- 在 Onebotv11Adapter 中添加对请求事件和元事件的处理
- 优化通知事件的处理逻辑
## fix
- 修复 Onebotv11Driver 中关闭 WebSocket 服务时出现 task attached to a different loop